### PR TITLE
Use 3.11 version as base image

### DIFF
--- a/circleci/Dockerfile
+++ b/circleci/Dockerfile
@@ -2,7 +2,7 @@
 # Dockerfile for udata builds on CircleCI 2.0 #
 ###############################################
 
-FROM udata/system:py3.10
+FROM udata/system:py3.11
 
 # File Author / Maintainer
 MAINTAINER Open Data Team

--- a/circleci/Dockerfile
+++ b/circleci/Dockerfile
@@ -2,7 +2,7 @@
 # Dockerfile for udata builds on CircleCI 2.0 #
 ###############################################
 
-FROM udata/system
+FROM udata/system:3.10
 
 # File Author / Maintainer
 MAINTAINER Open Data Team

--- a/circleci/Dockerfile
+++ b/circleci/Dockerfile
@@ -2,7 +2,7 @@
 # Dockerfile for udata builds on CircleCI 2.0 #
 ###############################################
 
-FROM udata/system:3.10
+FROM udata/system:py3.10
 
 # File Author / Maintainer
 MAINTAINER Open Data Team

--- a/system/Dockerfile
+++ b/system/Dockerfile
@@ -2,7 +2,7 @@
 # Dockerfile for udata system dependencies #
 ############################################
 
-FROM python:3.7-slim-buster
+FROM python:3.10-slim-buster
 
 # File Author / Maintainer
 MAINTAINER Open Data Team

--- a/system/Dockerfile
+++ b/system/Dockerfile
@@ -2,7 +2,7 @@
 # Dockerfile for udata system dependencies #
 ############################################
 
-FROM python:3.10-slim-buster
+FROM python:3.11-slim-buster
 
 # File Author / Maintainer
 MAINTAINER Open Data Team


### PR DESCRIPTION
Needed for https://github.com/opendatateam/udata/pull/2859

Not sure we should specify tag in [circleci/Dockerfile](https://github.com/opendatateam/udata-dockers/pull/6/commits/adcea68501e0427b46eb731f4f3286cdf7783296#diff-f7e8f6b6f3b8fcbbd916bfa689d3405520116af3abbf1a790013fb4f8d2abcfe).

- [x] publish on dockerhub
- [ ] check if libs installed in udata/system are still required following deps upgrade (pillow, lxml, etc.)